### PR TITLE
Remove the postversion script and add documentation on publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "exec": "npm run build && node dist/index.js",
     "genver": "genversion -s -e src/version.ts",
     "version": "npm run genver && git add . && npm run build",
-    "postversion": "git push",
     "test": "jest"
   },
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -44,12 +44,13 @@ If you want to use https://npm.digital-boss.cloud as npm registry, then install 
 ### Publish new version
 
 Commit new version and tag:
-- patch `src/version.ts`
-- `npm run build`
-- commit
-- `npm version patch`
+- `npm version patch` or minor or major, depending on your versioning needs
 - `git push`
-- push tag, for example: `git push origin v0.1.1`
+- push tag, for example: `git push origin v0.1.1`, or push all local tags: `git push --tags`
+
+Note: For more information on how the version scripts work check:
+https://docs.npmjs.com/cli/v8/commands/npm-version
+https://github.com/axelpale/genversion/blob/master/README.md
 
 Publish to npm:
 - npm login


### PR DESCRIPTION
What is done:
- removed the postversion pushing
- updated the README
- documented how to push local tags (npm version scripts add version tags automatically, see the documentation)

You can test it as:
```
# check tags
git tag
# increase version
npm version patch
# check tags
git tag
# remove unneeded version commit
git reset --soft HEAD~
# remove unneeded tag
git tag -d v0.1.15
```